### PR TITLE
Fix Base.Nothing and Base.String deprecation warnings

### DIFF
--- a/src/api.jl
+++ b/src/api.jl
@@ -14,10 +14,10 @@ Used to connect to database server. Returns a MYSQL handle on success and
 C_NULL on failure.
 """
 function mysql_real_connect(mysqlptr::Ptr{Void},
-                              host::String,
-                              user::String,
-                              passwd::String,
-                              db::String,
+                              host::AbstractString,
+                              user::AbstractString,
+                              passwd::AbstractString,
+                              db::AbstractString,
                               port::Cuint,
                               unix_socket::Ptr{Cchar},
                               @compat client_flag::UInt32)
@@ -135,7 +135,7 @@ Creates the sql string where the special chars are escaped
 """
 function mysql_real_escape_string(mysqlptr::Ptr{Void},
                                   to::Vector{Cuchar},
-                                  from::String,
+                                  from::AbstractString,
                                   length::Culong)
     return ccall((:mysql_real_escape_string, mysql_lib),
                  Cuint,
@@ -162,7 +162,7 @@ end
 """
 Creates the prepared statement. There should be only 1 statement
 """
-function mysql_stmt_prepare(stmtptr::Ptr{MYSQL_STMT}, sql::String)
+function mysql_stmt_prepare(stmtptr::Ptr{MYSQL_STMT}, sql::AbstractString)
     s = utf8(sql)
     return ccall((:mysql_stmt_prepare, mysql_lib),
                  Cint,
@@ -237,7 +237,7 @@ end
 """
 Executes the query and returns the status of the same.
 """
-function mysql_query(mysqlptr::Ptr{Void}, sql::String)
+function mysql_query(mysqlptr::Ptr{Void}, sql::AbstractString)
     return ccall((:mysql_query, mysql_lib),
                  Cchar,
                  (Ptr{Void}, Ptr{Cuchar}),

--- a/src/datetime.jl
+++ b/src/datetime.jl
@@ -27,28 +27,28 @@ function MySQLDateTime(mtime::MYSQL_TIME)
     MySQLDateTime(MySQLDate(mtime), MySQLTime(mtime))
 end
 
-function Base.convert(::Type{String}, time::MySQLTime)
+function Base.convert(::Type{AbstractString}, time::MySQLTime)
     "$(time.hour):$(time.minute):$(time.second)"
 end
 
-function Base.convert(::Type{String}, date::MySQLDate)
+function Base.convert(::Type{AbstractString}, date::MySQLDate)
     "$(date.year)-$(date.month)-$(date.day)"
 end
 
-function Base.convert(::Type{String}, dtime::MySQLDateTime)
-    convert(String, dtime.date) * " " * convert(String, dtime.time)
+function Base.convert(::Type{AbstractString}, dtime::MySQLDateTime)
+    convert(AbstractString, dtime.date) * " " * convert(AbstractString, dtime.time)
 end
 
 function Base.show(io::IO, date::MySQLDate)
-    print(io, convert(String, date))
+    print(io, convert(AbstractString, date))
 end
 
 function Base.show(io::IO, time::MySQLTime)
-    print(io, convert(String, time))
+    print(io, convert(AbstractString, time))
 end
 
 function Base.show(io::IO, dtime::MySQLDateTime)
-    print(io, convert(String, dtime))
+    print(io, convert(AbstractString, dtime))
 end
 
 function Base.convert(::Type{MYSQL_TIME}, time::MySQLTime)

--- a/src/handy.jl
+++ b/src/handy.jl
@@ -6,10 +6,10 @@ using Compat
 A handy function that wraps mysql_init and mysql_real_connect. Also does error
 checking on the pointers returned by init and real_connect.
 """
-function mysql_connect(host::String,
-                        user::String,
-                        passwd::String,
-                        db::String,
+function mysql_connect(host::AbstractString,
+                        user::AbstractString,
+                        passwd::AbstractString,
+                        db::AbstractString,
                         port::Cuint,
                         unix_socket::Ptr{Cchar},
                         client_flag)
@@ -41,7 +41,7 @@ end
 Wrapper over mysql_real_connect with CLIENT_MULTI_STATEMENTS passed
 as client flag options.
 """
-function mysql_connect(hostName::String, userName::String, password::String, db::String)
+function mysql_connect(hostName::AbstractString, userName::AbstractString, password::AbstractString, db::AbstractString)
     return mysql_connect(hostName, userName, password, db, convert(Cuint, 0),
                          convert(Ptr{Cchar}, C_NULL), CLIENT_MULTI_STATEMENTS)
 end
@@ -58,7 +58,7 @@ function mysql_disconnect(hndl)
     hndl.host = ""
     hndl.user = ""
     hndl.db = ""
-    Nothing
+    Void
 end
 
 # wrappers to take MySQLHandle as input as well as check for NULL pointer.
@@ -97,7 +97,7 @@ function mysql_execute_query(mysqlptr::Ptr{Void}, command, opformat=MYSQL_DATA_F
     while true
         result = mysql_store_result(mysqlptr)
         if result != C_NULL # if select query
-            retval = Nothing
+            retval = Void
             if opformat == MYSQL_DATA_FRAME
                 retval = mysql_result_to_dataframe(result)
             else opformat == MYSQL_ARRAY
@@ -148,7 +148,7 @@ end
 mysql_display_error(hndl, condition::Bool) = mysql_display_error(hndl, condition, "")
 mysql_display_error(hndl, response, msg) = mysql_display_error(hndl, response != 0, msg)
 mysql_display_error(hndl, response) = mysql_display_error(hndl, response, "")
-mysql_display_error(hndl, msg::String) = mysql_display_error(hndl, true, msg)
+mysql_display_error(hndl, msg::AbstractString) = mysql_display_error(hndl, true, msg)
 
 """
 Given a prepared statement pointer `stmtptr` returns a dataframe containing the results.

--- a/src/types.jl
+++ b/src/types.jl
@@ -3,9 +3,9 @@ The MySQL handle.
 """
 type MySQLHandle
     mysqlptr::Ptr{Void}
-    host::String
-    user::String
-    db::String
+    host::AbstractString
+    user::AbstractString
+    db::AbstractString
 end
 
 function Base.show(io::IO, hndl::MySQLHandle)
@@ -131,7 +131,7 @@ immutable MYSQL_BIND
         MYSQL_BIND(convert(Ptr{Void}, pointer(arr)), sizeof(arr), bufftype)
     end
 
-    function MYSQL_BIND(str::String, bufftype)
+    function MYSQL_BIND(str::AbstractString, bufftype)
         MYSQL_BIND(convert(Ptr{Void}, pointer(str)), sizeof(str), bufftype)
     end
 end


### PR DESCRIPTION
Fixes for deprecation warnings. Repaced String with AbstractString and Nothing with Void.