### PR TITLE
Suggestion for peformance improvement

### DIFF
--- a/src/datetime.jl
+++ b/src/datetime.jl
@@ -1,5 +1,7 @@
 # Constructors for the julia Date, Time and DateTime types.
 
+import Base.==
+
 function MySQLTime(timestr)
     h, m, s = split(timestr, ':')
     MySQLTime(parse(Cint, h), parse(Cint, m), parse(Cint, s))

--- a/src/results.jl
+++ b/src/results.jl
@@ -91,60 +91,17 @@ mysql_get_ctype(mysqltype::MYSQL_TYPE) = mysql_get_ctype(mysql_get_julia_type(my
 """
 Interpret a string as a julia datatype.
 """
-function mysql_interpret_field(strval::AbstractString, jtype::DataType)
-    if (jtype == Cuchar)
-        return convert(Cuchar, strval[1])
+mysql_interpret_field(strval::AbstractString, jtype::Type{Cuchar})=strval[1]
 
-    elseif (jtype == Cchar || jtype == Cshort || jtype == Cint ||
-            jtype == Int64 || jtype == Cfloat || jtype == Cdouble)
-        return parse(jtype, strval)
+mysql_interpret_field{T<:Number}(strval::AbstractString, jtype::Type{T})=parse(T, strval)
 
-    elseif (jtype == MySQLDate)
-        return MySQLDate(strval)
+mysql_interpret_field{T<:AbstractString}(strval::AbstractString, jtype::Type{T})=strval
 
-    elseif (jtype == MySQLTime)
-        return MySQLTime(strval)
+mysql_interpret_field(strval::AbstractString, jtype::Type{MySQLDate})=MySQLDate(strval)
 
-    elseif (jtype == MySQLDateTime)
-        return MySQLDateTime(strval)
+mysql_interpret_field(strval::AbstractString, jtype::Type{MySQLTime})=MySQLTime(strval)
 
-    else
-        return strval
-
-    end
-
-end
-
-function mysql_interpret_field(strval, jtype::Cuchar)
-	return strval[1]
-end
-
-function mysql_interpret_field{T<:Number}(strval, jtype::T)	
-	return parse(T, strval)
-end
-
-function mysql_interpret_field{T<:AbstractString}(strval, jtype::T)
-	return strval
-end
-
-function mysql_interpret_field(strval, jtype::AbstractString)
-	return strval
-end
-
-function mysql_interpret_field(strval, jtype::MySQLDate)
-	return MySQLDate(strval)
-end
-
-function mysql_interpret_field(strval, jtype::MySQLTime)
-	return MySQLTime(strval)
-end
-
-function mysql_interpret_field(strval, jtype::MySQLDateTime)
-	return MySQLDateTime(strval)
-end
-function mysql_interpret_field(strval,jtype)
-	return mysql_interpret_field(strval, typeof(jtype))
-end
+mysql_interpret_field(strval::AbstractString, jtype::Type{MySQLDateTime})=MySQLDateTime(strval)
 
 """
 Load a bytestring from `result` pointer given the field index `idx`.
@@ -267,38 +224,15 @@ end
 """
 Fill the row indexed by `row` of the dataframe `df` with values from `result`.
 """
-function populate_row!(df, mysqlfield_types::Array{MYSQL_TYPE}, result::MYSQL_ROW, row, jfield_types_instances)
+function populate_row!(df, mysqlfield_types::Array{MYSQL_TYPE}, result::MYSQL_ROW, row, jfield_types)
     for i = 1:length(mysqlfield_types)
         strval = mysql_load_string_from_resultptr(result, i)
 		if strval == Void
             df[row, i] = NA
         else			
-            df[row, i] = mysql_interpret_field(strval, jfield_types_instances[i])
+            df[row, i] = mysql_interpret_field(strval, jfield_types[i])
         end
     end
-end
-
-"""
-Creates a vector of instances with types specified by the vector coltypes
-"""
-function create_typelist(coltypes)
-	res=Any[]
-	for i=1:length(coltypes)
-		if coltypes[i]<:Number
-			push!(res, zero(coltypes[i]))			
-		elseif coltypes[i]<:AbstractString
-			push!(res, convert(UTF8String, ""))	#UTF8String is an arbitrary choice here		
-		elseif coltypes[i]==MySQLDate
-			push!(res, MySQLDate(1,1,1))
-		elseif coltypes[i]==MySQLTime
-			push!(res, MySQLTime(1,1,1))
-		elseif coltypes[i]==MySQLDateTime
-			push!(res, MySQLDateTime(MySQLDate(1,1,1), MySQLTime(1,1,1)))
-		else
-			error("Unknown column type: $(coltypes[i])")			
-		end		
-	end
-	return res
 end
 
 """
@@ -321,9 +255,9 @@ function mysql_result_to_dataframe(result::MYSQL_RES)
     end
 
     df = DataFrame(jfield_types, field_headers, @compat Int64(nrows))
-    jfield_types_instances=create_typelist(jfield_types) #Column types will be the same for each row			
+	
 	for row = 1:nrows
-		populate_row!(df, mysqlfield_types, mysql_fetch_row(result), row, jfield_types_instances)
+		populate_row!(df, mysqlfield_types, mysql_fetch_row(result), row, jfield_types)
 	end
     return df
 end

--- a/src/results.jl
+++ b/src/results.jl
@@ -115,35 +115,35 @@ function mysql_interpret_field(strval::AbstractString, jtype::DataType)
 
 end
 
-function mysql_interpret_field(strval,jtype::Cuchar)
+function mysql_interpret_field(strval, jtype::Cuchar)
 	return strval[1]
 end
 
-function mysql_interpret_field{T<:Number}(strval,jtype::T)	
+function mysql_interpret_field{T<:Number}(strval, jtype::T)	
 	return parse(T, strval)
 end
 
-function mysql_interpret_field{T<:AbstractString}(strval,jtype::T)
+function mysql_interpret_field{T<:AbstractString}(strval, jtype::T)
 	return strval
 end
 
-function mysql_interpret_field(strval,jtype::AbstractString)
+function mysql_interpret_field(strval, jtype::AbstractString)
 	return strval
 end
 
-function mysql_interpret_field(strval,jtype::MySQLDate)
+function mysql_interpret_field(strval, jtype::MySQLDate)
 	return MySQLDate(strval)
 end
 
-function mysql_interpret_field(strval,jtype::MySQLTime)
+function mysql_interpret_field(strval, jtype::MySQLTime)
 	return MySQLTime(strval)
 end
 
-function mysql_interpret_field(strval,jtype::MySQLDateTime)
+function mysql_interpret_field(strval, jtype::MySQLDateTime)
 	return MySQLDateTime(strval)
 end
 function mysql_interpret_field(strval,jtype)
-	return mysql_interpret_field(strval,typeof(jtype))
+	return mysql_interpret_field(strval, typeof(jtype))
 end
 
 """
@@ -267,13 +267,13 @@ end
 """
 Fill the row indexed by `row` of the dataframe `df` with values from `result`.
 """
-function populate_row!(df, mysqlfield_types::Array{MYSQL_TYPE}, result::MYSQL_ROW, row,jfield_types_instances)
+function populate_row!(df, mysqlfield_types::Array{MYSQL_TYPE}, result::MYSQL_ROW, row, jfield_types_instances)
     for i = 1:length(mysqlfield_types)
         strval = mysql_load_string_from_resultptr(result, i)
 		if strval == Void
             df[row, i] = NA
         else			
-            df[row, i] = mysql_interpret_field(strval,jfield_types_instances[i])
+            df[row, i] = mysql_interpret_field(strval, jfield_types_instances[i])
         end
     end
 end
@@ -285,19 +285,18 @@ function create_typelist(coltypes)
 	res=Any[]
 	for i=1:length(coltypes)
 		if coltypes[i]<:Number
-			push!(res,zero(coltypes[i]))			
+			push!(res, zero(coltypes[i]))			
 		elseif coltypes[i]<:AbstractString
-			push!(res,convert(UTF8String,""))	#UTF8String is an arbitrary choice here		
+			push!(res, convert(UTF8String, ""))	#UTF8String is an arbitrary choice here		
 		elseif coltypes[i]==MySQLDate
-			push!(MySQLDate(1,1,1))
+			push!(res, MySQLDate(1,1,1))
 		elseif coltypes[i]==MySQLTime
-			push!(MySQLTime(1,1,1))
+			push!(res, MySQLTime(1,1,1))
 		elseif coltypes[i]==MySQLDateTime
-			push!(MySQLDateTime(MySQLDate(1,1,1),MySQLTime(1,1,1)))
+			push!(res, MySQLDateTime(MySQLDate(1,1,1), MySQLTime(1,1,1)))
 		else
 			error("Unknown column type: $(coltypes[i])")			
-		end
-		
+		end		
 	end
 	return res
 end
@@ -322,11 +321,9 @@ function mysql_result_to_dataframe(result::MYSQL_RES)
     end
 
     df = DataFrame(jfield_types, field_headers, @compat Int64(nrows))
-
-    jfield_types_instances=create_typelist(jfield_types) #Column types will be the same for each row	
-		
+    jfield_types_instances=create_typelist(jfield_types) #Column types will be the same for each row			
 	for row = 1:nrows
-		populate_row!(df, mysqlfield_types, mysql_fetch_row(result), row,jfield_types_instances)
+		populate_row!(df, mysqlfield_types, mysql_fetch_row(result), row, jfield_types_instances)
 	end
     return df
 end

--- a/src/results.jl
+++ b/src/results.jl
@@ -115,6 +115,37 @@ function mysql_interpret_field(strval::AbstractString, jtype::DataType)
 
 end
 
+function mysql_interpret_field(strval, jtype::Cuchar)
+	return strval[1]
+end
+
+function mysql_interpret_field{T<:Number}(strval, jtype::T)	
+	return parse(T, strval)
+end
+
+function mysql_interpret_field{T<:AbstractString}(strval, jtype::T)
+	return strval
+end
+
+function mysql_interpret_field(strval, jtype::AbstractString)
+	return strval
+end
+
+function mysql_interpret_field(strval, jtype::MySQLDate)
+	return MySQLDate(strval)
+end
+
+function mysql_interpret_field(strval, jtype::MySQLTime)
+	return MySQLTime(strval)
+end
+
+function mysql_interpret_field(strval, jtype::MySQLDateTime)
+	return MySQLDateTime(strval)
+end
+function mysql_interpret_field(strval,jtype)
+	return mysql_interpret_field(strval, typeof(jtype))
+end
+
 """
 Load a bytestring from `result` pointer given the field index `idx`.
 """
@@ -236,17 +267,38 @@ end
 """
 Fill the row indexed by `row` of the dataframe `df` with values from `result`.
 """
-function populate_row!(df, mysqlfield_types::Array{MYSQL_TYPE}, result::MYSQL_ROW, row)
+function populate_row!(df, mysqlfield_types::Array{MYSQL_TYPE}, result::MYSQL_ROW, row, jfield_types_instances)
     for i = 1:length(mysqlfield_types)
         strval = mysql_load_string_from_resultptr(result, i)
-
-        if strval == Void
+		if strval == Void
             df[row, i] = NA
-        else
-            df[row, i] = mysql_interpret_field(strval,
-                                               mysql_get_julia_type(mysqlfield_types[i]))
+        else			
+            df[row, i] = mysql_interpret_field(strval, jfield_types_instances[i])
         end
     end
+end
+
+"""
+Creates a vector of instances with types specified by the vector coltypes
+"""
+function create_typelist(coltypes)
+	res=Any[]
+	for i=1:length(coltypes)
+		if coltypes[i]<:Number
+			push!(res, zero(coltypes[i]))			
+		elseif coltypes[i]<:AbstractString
+			push!(res, convert(UTF8String, ""))	#UTF8String is an arbitrary choice here		
+		elseif coltypes[i]==MySQLDate
+			push!(res, MySQLDate(1,1,1))
+		elseif coltypes[i]==MySQLTime
+			push!(res, MySQLTime(1,1,1))
+		elseif coltypes[i]==MySQLDateTime
+			push!(res, MySQLDateTime(MySQLDate(1,1,1), MySQLTime(1,1,1)))
+		else
+			error("Unknown column type: $(coltypes[i])")			
+		end		
+	end
+	return res
 end
 
 """
@@ -269,11 +321,10 @@ function mysql_result_to_dataframe(result::MYSQL_RES)
     end
 
     df = DataFrame(jfield_types, field_headers, @compat Int64(nrows))
-
-    for row = 1:nrows
-        populate_row!(df, mysqlfield_types, mysql_fetch_row(result), row)
-    end
-
+    jfield_types_instances=create_typelist(jfield_types) #Column types will be the same for each row			
+	for row = 1:nrows
+		populate_row!(df, mysqlfield_types, mysql_fetch_row(result), row, jfield_types_instances)
+	end
     return df
 end
 


### PR DESCRIPTION
Hi
I noted that we call the function mysql_get_julia_type(mysqlfield_types[i]) for each row which is processed.
Is that truly necessary? It seems that the type of the columns should be constant in any MySQLDB.
I made some minor changes to reflect this. 

In the tests I made, this code ran **considerably faster (by a factor 2 or so)** than the current master.
Can you please take a look?

Also, I was hoping to increase performance by using multiple dispatch instead of if queries.

I am not sure at all whether I did everything right with regards to Time and Date formats.

Unfortunately I could not perform any tests, as I do not have that DB which the tests require.

Thank you.
Bernhard