### PR TITLE
Changes for cleanup, update and performance.

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Execute a multi query:
 ```
 command = """INSERT INTO Employee (Name) VALUES ('');
              UPDATE Employee SET LunchTime = '15:00:00' WHERE LENGTH(Name) > 5;"""
-data = mysql_execute_multi_query(con, command)
+data = mysql_execute_query(con, command)
 ```
 
 `data` contains an array of dataframes (or arrays if MYSQL_ARRAY was specified as the

--- a/src/MySQL.jl
+++ b/src/MySQL.jl
@@ -10,7 +10,7 @@ module MySQL
     export mysql_get_julia_type, mysql_interpret_field, mysql_load_string_from_resultptr,
            mysql_get_row_as_vector, mysql_get_result_as_array, mysql_result_to_dataframe, 
            mysql_connect, mysql_disconnect, mysql_display_error,
-           mysql_query, mysql_execute_query, mysql_execute_multi_query,
+           mysql_query, mysql_execute_query,
            mysql_stmt_init, mysql_stmt_prepare, mysql_stmt_execute,
            mysql_stmt_close, mysql_stmt_result_to_dataframe, mysql_store_result,
            mysql_free_result, mysql_stmt_bind_param, mysql_stmt_affected_rows

--- a/src/results.jl
+++ b/src/results.jl
@@ -224,8 +224,8 @@ end
 """
 Fill the row indexed by `row` of the dataframe `df` with values from `result`.
 """
-function populate_row!(df, mysqlfield_types::Array{MYSQL_TYPE}, result::MYSQL_ROW, row, jfield_types)
-    for i = 1:length(mysqlfield_types)
+function populate_row!(df, nfields, result::MYSQL_ROW, row, jfield_types)
+    for i = 1:nfields
         strval = mysql_load_string_from_resultptr(result, i)
 		if strval == Void
             df[row, i] = NA
@@ -257,7 +257,7 @@ function mysql_result_to_dataframe(result::MYSQL_RES)
     df = DataFrame(jfield_types, field_headers, @compat Int64(nrows))
 	
 	for row = 1:nrows
-		populate_row!(df, mysqlfield_types, mysql_fetch_row(result), row, jfield_types)
+		populate_row!(df, nfields, mysql_fetch_row(result), row, jfield_types)
 	end
     return df
 end

--- a/src/types.jl
+++ b/src/types.jl
@@ -205,7 +205,7 @@ Iterator for the mysql result (MYSQL_RES).
 type MySQLRowIterator
     result::MYSQL_RES
     row::Array{Any, 1}
-    mysqlfield_types::Array{MYSQL_TYPE, 1}
+    jfield_types::Array{Type, 1}
     rowsleft::Int64
 end
 

--- a/test/Benchmarks/benchmark.jl
+++ b/test/Benchmarks/benchmark.jl
@@ -24,7 +24,7 @@ function mysql_benchmarks(queries; use_prepare=0, use_multiquery = 0, operation=
     elseif use_multiquery == 1
         println("*** Multi query test ")
         temp = join(queries)
-        @time mysql_execute_multi_query(conn, temp)
+        @time mysql_execute_query(conn, temp)
     else
         println("*** Normal test ")
         @time for i = 1:size(queries, 1)
@@ -60,7 +60,7 @@ function init_test()
         empno SMALLINT,
         PRIMARY KEY (ID));"""
 
-    mysql_execute_multi_query(conn, query)
+    mysql_execute_query(conn, query)
     println("*** Done initializing test.")
 end
 

--- a/test/Benchmarks/create_datasets.jl
+++ b/test/Benchmarks/create_datasets.jl
@@ -22,7 +22,7 @@ end
 
 function insert_queries(number_of_datasets)
     println("*** Generating insert queries for $number_of_datasets tuples")
-    insert_query = Array(String, number_of_datasets)
+    insert_query = Array(AbstractString, number_of_datasets)
     varcha, rfloat, datetime, tint, enume, mint, rint, bint, dfloat, dpfloat, chara, sint = create_queries(number_of_datasets)
     for i = 1:number_of_datasets
         insert_query[i] = "INSERT INTO Employee (Name, Salary, LastLogin, OfficeNo, JobType,h, n, z, z1, z2, cha, empno) VALUES ('$(varcha[i])', $(rfloat[i]), '$(datetime[i])', $(tint[i]), '$(enume[i])', $(mint[i]), $(rint[i]), $(bint[i]), $(dfloat[i]), $(dpfloat[i]), '$(chara[i])', $(sint[i]));"
@@ -35,7 +35,7 @@ end
 function update_queries(number_of_datasets)
     println("*** Generating update queries for $number_of_datasets tuples")
     number_of_datasets = number_of_datasets
-    update_query = Array(String, number_of_datasets)
+    update_query = Array(AbstractString, number_of_datasets)
     varcha, rfloat, datetime, tint, enume, mint, rint, bint, dfloat, dpfloat, chara, sint = create_queries(number_of_datasets)
     for i = 1:number_of_datasets
         update_query[i] = "UPDATE Employee SET Name='$(varcha[i])', Salary=$(rfloat[i]), LastLogin='$(datetime[i])', OfficeNo=$(tint[i]), JobType='$(enume[i])', h=$(mint[i]), n=$(rint[i]), z=$(bint[i]), z1=$(dfloat[i]), z2=$(dpfloat[i]), cha='$(chara[i])', empno=$(sint[i]) where ID = $i;"

--- a/test/test_basic.jl
+++ b/test/test_basic.jl
@@ -57,11 +57,12 @@ function show_results()
     command = """SELECT * FROM Employee;"""
     dframe = mysql_execute_query(hndl, command)
     println("\n *** Results as Dataframe: \n", dframe)
-    println(DataFrameResults)
+    println("\n *** Expected Result: \n", DataFrameResults)
     @test dfisequal(dframe, DataFrameResults)
 
     retarr = mysql_execute_query(hndl, command, MYSQL_ARRAY)
     println("\n *** Results as Array: \n", retarr)
+    println("\n *** Expected Result: \n", ArrayResults)
 
     println("\n *** Results using Iterator: \n")
     response = mysql_query(hndl, command)

--- a/test/test_prep.jl
+++ b/test/test_prep.jl
@@ -149,7 +149,8 @@ function show_results()
 
     dframe = mysql_stmt_result_to_dataframe(stmt)
     mysql_stmt_close(stmt)
-    println(dframe)
+    println("\n *** Results as dataframe: \n", dframe)
+    println("\n *** Expected result: \n", DataFrameResultsPrep)
     @test dfisequal(dframe, DataFrameResultsPrep)
 end
 


### PR DESCRIPTION
1) Removed unused `mysqlfield_types` array in `populate_row!()`.
2) Update readme and test/Benchmarks for removal of `mysql_execute_multi_query()`.
3) Incorporate #22 to `mysql_get_row_as_vector!()` and related functions.
4) Some cosmetic changes to remove tabs.