### PR TITLE
Fix timestamp issue

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,3 @@
 DataFrames
 Compat
+Requires

--- a/src/datetime.jl
+++ b/src/datetime.jl
@@ -1,5 +1,7 @@
 # Constructors for the julia Date, Time and DateTime types.
 
+using Requires
+
 import Base.==
 
 function MySQLTime(timestr)
@@ -76,4 +78,12 @@ end
 
 function ==(a::MySQLDateTime, b::MySQLDateTime)
     a.date == b.date && a.time == b.time
+end
+
+@require Dates begin
+using Dates
+Base.convert(::Type{Date}, date::MySQLDate) = Date(date.year, date.month, date.day)
+Base.convert(::Type{DateTime}, dtime::MySQLDateTime) =
+    DateTime(dtime.date.year, dtime.date.month, dtime.date.day,
+             dtime.time.hour, dtime.time.minute, dtime.time.second)
 end

--- a/src/results.jl
+++ b/src/results.jl
@@ -53,7 +53,7 @@ function mysql_get_julia_type(mysqltype::MYSQL_TYPE)
         return Clong
 
     elseif (mysqltype == MYSQL_TYPE_TIMESTAMP)
-        return Cint
+        return MySQLDateTime
 
     elseif (mysqltype == MYSQL_TYPE_DATE)
         return MySQLDate


### PR DESCRIPTION
This is a fix for #26 

MySQL timestamps were being interpreted as `Int32`'s, but were received as date time strings.  Changed datatype from `Int32` to `MySQLDateTime`.