### PR TITLE
Added mysql_insert_id()

### DIFF
--- a/src/api.jl
+++ b/src/api.jl
@@ -368,3 +368,11 @@ function mysql_stmt_affected_rows(stmt::Ptr{MYSQL_STMT})
     return ccall((:mysql_stmt_affected_rows, mysql_lib),
                  Culong, (Ptr{Void}, ), stmt)
 end
+
+"""
+Get the last insert id for auto increment id's.
+"""
+function mysql_insert_id(mysqlptr::Ptr{Void})
+    return ccall((:mysql_insert_id, mysql_lib),
+                 Culong, (Ptr{Void}, ), mysqlptr)
+end

--- a/src/handy.jl
+++ b/src/handy.jl
@@ -77,7 +77,8 @@ end
 
 # wrappers to take MySQLHandle as input as well as check for NULL pointer.
 for func = (:mysql_query, :mysql_store_result, :mysql_field_count, :mysql_affected_rows,
-            :mysql_next_result, :mysql_error, :mysql_execute_query, :mysql_options)
+            :mysql_next_result, :mysql_error, :mysql_execute_query, :mysql_options,
+            :mysql_insert_id)
     eval(quote
         function ($func)(hndl::MySQLHandle, args...)
             if hndl.mysqlptr == C_NULL
@@ -232,4 +233,4 @@ mysql_bind_init(jtype::@compat(Union{Type{Date}, Type{DateTime}}), typ, value) =
 mysql_bind_init(::Type{AbstractString}, typ, value) = MYSQL_BIND(value, typ)
 mysql_bind_init(jtype, typ, value) = MYSQL_BIND([convert(jtype, value)], typ)
 
-export mysql_bind_init
+export mysql_bind_init, mysql_insert_id


### PR DESCRIPTION
Added wrapper to `mysql_insert_id()`.  Returns the last insert's auto increment id.