### PR TITLE
Remove the need to call `mysql_stmt_init` and `mysql_stmt_close`

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,23 +61,21 @@ Prepared statements are used to optimize queries.  Queries that are run repeated
  An Example:
 
 ```julia
-stmt = mysql_stmt_init(con)
-mysql_stmt_prepare(stmt, "INSERT INTO Employee (Name, Salary, JoinDate) values (?, ?, ?);")
+mysql_stmt_prepare(conn, "INSERT INTO Employee (Name, Salary, JoinDate) values (?, ?, ?);")
 
 values = [("John", 10000.50, "2015-8-3"),
           ("Tom", 20000.25, "2015-8-4"),
           ("Jim", 30000.00, "2015-6-2")]
 
 for val in values
-    mysql_execute_query(stmt, [MYSQL_TYPE_VARCHAR, MYSQL_TYPE_FLOAT, MYSQL_TYPE_DATE], val)
+    mysql_execute_query(conn, [MYSQL_TYPE_VARCHAR, MYSQL_TYPE_FLOAT, MYSQL_TYPE_DATE], val)
 end
 
-mysql_stmt_prepare(stmt, "SELECT * from Employee WHERE ID = ? AND Salary > ?")
-dframe = mysql_execute_query(stmt, [MYSQL_TYPE_LONG, MYSQL_TYPE_FLOAT], [5, 35000.00])
-mysql_stmt_close(stmt)
+mysql_stmt_prepare(conn, "SELECT * from Employee WHERE ID = ? AND Salary > ?")
+dframe = mysql_execute_query(conn, [MYSQL_TYPE_LONG, MYSQL_TYPE_FLOAT], [5, 35000.00])
 
 # To iterate over the result and get each row as a tuple
-for row in MySQLRowIterator(stmt, [MYSQL_TYPE_LONG, MYSQL_TYPE_FLOAT], [5, 35000.00])
+for row in MySQLRowIterator(conn, [MYSQL_TYPE_LONG, MYSQL_TYPE_FLOAT], [5, 35000.00])
     # do stuff with row
 end
 ```

--- a/src/iterators.jl
+++ b/src/iterators.jl
@@ -10,13 +10,13 @@ function MySQLRowIterator(con::MySQLHandle, command)
     return MySQLRowIterator(result)
 end
 
-function MySQLRowIterator(stmt::MySQLStatementHandle, typs, values)
+function MySQLRowIterator(hndl::MySQLHandle, typs, values)
     bindarr = mysql_bind_array(typs, values)
-    mysql_stmt_bind_param(stmt, bindarr)
-    return MySQLRowIterator(stmt)
+    mysql_stmt_bind_param(hndl, bindarr)
+    return MySQLRowIterator(hndl)
 end
 
-MySQLRowIterator(stmt::MySQLStatementHandle) = MySQLStatementIterator(stmt)
+MySQLRowIterator(hndl::MySQLHandle) = MySQLStatementIterator(hndl)
 
 Base.start(itr::MySQLRowIterator) = true
 
@@ -29,12 +29,12 @@ end
 
 Base.done(itr::MySQLRowIterator, state) = itr.rowsleft == 0
 
-function MySQLStatementIterator(stmt::MySQLStatementHandle)
-    meta = mysql_metadata(stmt)
+function MySQLStatementIterator(hndl::MySQLHandle)
+    meta = mysql_metadata(hndl)
     bindres = mysql_bind_array(meta)
-    mysql_stmt_bind_result(stmt, bindres)
-    mysql_stmt_execute(stmt)
-    return MySQLStatementIterator(stmt, meta.jtypes, meta.is_nullables, bindres)
+    mysql_stmt_bind_result(hndl, bindres)
+    mysql_stmt_execute(hndl)
+    return MySQLStatementIterator(hndl, meta.jtypes, meta.is_nullables, bindres)
 end
 
 Base.start(itr::MySQLStatementIterator) = true
@@ -42,4 +42,4 @@ Base.start(itr::MySQLStatementIterator) = true
 Base.next(itr::MySQLStatementIterator, state) =
     (mysql_get_row_as_tuple(itr.binding, itr.jtypes, itr.is_nullables), state)
 
-Base.done(itr::MySQLStatementIterator, state) = mysql_stmt_fetch(itr.stmt) == MYSQL_NO_DATA
+Base.done(itr::MySQLStatementIterator, state) = mysql_stmt_fetch(itr.hndl) == MYSQL_NO_DATA

--- a/src/results.jl
+++ b/src/results.jl
@@ -348,29 +348,29 @@ mysql_init_dataframe(meta::Array{MYSQL_FIELD}, nrows) =
 mysql_init_dataframe(meta, nrows) =
     DataFrame(meta.jtypes, map(symbol, meta.names), @compat Int64(nrows))
 
-function mysql_result_to_dataframe(stmt::MySQLStatementHandle)
-    meta = mysql_metadata(stmt.stmtptr)
+function mysql_result_to_dataframe(hndl::MySQLHandle)
+    meta = mysql_metadata(hndl.stmtptr)
     bindres = mysql_bind_array(meta)
-    mysql_stmt_bind_result(stmt, bindres)
-    mysql_stmt_store_result(stmt)
-    nrows = mysql_stmt_num_rows(stmt)
+    mysql_stmt_bind_result(hndl, bindres)
+    mysql_stmt_store_result(hndl)
+    nrows = mysql_stmt_num_rows(hndl)
     df = mysql_init_dataframe(meta, nrows)
     for ridx = 1:nrows
-        mysql_stmt_fetch(stmt)
+        mysql_stmt_fetch(hndl)
         stmt_populate_row!(df, ridx, bindres)
     end
     return df
 end
 
-function mysql_get_result_as_tuples(stmt::MySQLStatementHandle)
-    meta = mysql_metadata(stmt)
+function mysql_get_result_as_tuples(hndl::MySQLHandle)
+    meta = mysql_metadata(hndl)
     bindres = mysql_bind_array(meta)
-    mysql_stmt_bind_result(stmt, bindres)
-    mysql_stmt_store_result(stmt)
-    nrows = mysql_stmt_num_rows(stmt)
+    mysql_stmt_bind_result(hndl, bindres)
+    mysql_stmt_store_result(hndl)
+    nrows = mysql_stmt_num_rows(hndl)
     retarr = Array(Tuple, nrows)
     for i = 1:nrows
-        mysql_stmt_fetch(stmt)
+        mysql_stmt_fetch(hndl)
         retarr[i] = mysql_get_row_as_tuple(bindres, meta.jtypes, meta.is_nullables)
     end
     return retarr

--- a/test/test_prep.jl
+++ b/test/test_prep.jl
@@ -43,29 +43,24 @@ const DataFrameResultsPrep = DataFrame(
      Nullable{Int8}(), Nullable{AbstractString}(), Nullable{UInt8}(), Nullable{Int16}()]]
 
 function run_query_helper(command, msg)
-    stmt = mysql_stmt_init(hndl)
-    mysql_stmt_prepare(stmt, command)
-    mysql_execute_query(stmt)
-    mysql_stmt_close(stmt)
+    mysql_stmt_prepare(hndl, command)
+    mysql_execute_query(hndl)
     println("Success: " * msg)
     return true
 end
 
 function update_values()
     command = """UPDATE Employee SET Salary = ? WHERE ID > ?;"""
-    stmt = mysql_stmt_init(hndl)
-    mysql_stmt_prepare(stmt, command)
-    affrows = mysql_execute_query(stmt, [MYSQL_TYPE_FLOAT, MYSQL_TYPE_LONG], [25000, 2])
+    mysql_stmt_prepare(hndl, command)
+    affrows = mysql_execute_query(hndl, [MYSQL_TYPE_FLOAT, MYSQL_TYPE_LONG], [25000, 2])
     println("Affected rows after update_values(): $affrows")
-    mysql_stmt_close(stmt)
     return true
 end
 
 function insert_values()
     command = """INSERT INTO Employee (Name, Salary, JoinDate, LastLogin, LunchTime, OfficeNo, empno) VALUES (?, ?, ?, ?, ?, ?, ?);"""
 
-    stmt = mysql_stmt_init(hndl)
-    mysql_stmt_prepare(stmt, command)
+    mysql_stmt_prepare(hndl, command)
     values = [("John", 10000.50, "2015-8-3", "2015-9-5 12:31:30", "12:00:00", 1, 1301),
               ("Tom", 20000.25, "2015-8-4", "2015-10-12 13:12:14", "13:00:00", 12, 1422),
               ("Jim", 30000.00, "2015-6-2", "2015-9-5 10:05:10", "12:30:00", 45, 1567),
@@ -77,49 +72,45 @@ function insert_values()
 
     affrows = 0
     for value in values
-        affrows += mysql_execute_query(stmt, typs, value)
+        affrows += mysql_execute_query(hndl, typs, value)
     end
 
     println("Affected rows after insert_values(): $affrows")
-    mysql_stmt_close(stmt)
     true
 end
 
 function show_results()
     command = "SELECT * FROM Employee WHERE ID > ?;"
-    stmt = mysql_stmt_init(hndl)
-    mysql_stmt_prepare(stmt, command)
-    dframe = mysql_execute_query(stmt, [MYSQL_TYPE_LONG], [0])
+    mysql_stmt_prepare(hndl, command)
+    dframe = mysql_execute_query(hndl, [MYSQL_TYPE_LONG], [0])
     println("\n *** Results as dataframe: \n", dframe)
     println("\n *** Expected result: \n", DataFrameResultsPrep)
     @test dfisequal(dframe, DataFrameResultsPrep)
 
-    mysql_stmt_prepare(stmt, command)
+    mysql_stmt_prepare(hndl, command)
     println("\n *** Results using Iterator: \n")
     i = 1
-    for row in MySQLRowIterator(stmt, [MYSQL_TYPE_LONG], [0])
+    for row in MySQLRowIterator(hndl, [MYSQL_TYPE_LONG], [0])
         println(row)
         @test compare_rows(row, ArrayResultsPrep[i])
         i += 1
     end
 
-    mysql_stmt_prepare(stmt, command)
+    mysql_stmt_prepare(hndl, command)
     println("\n *** Results as tuples: \n")
-    tupres = mysql_execute_query(stmt, [MYSQL_TYPE_LONG], [0]; opformat=MYSQL_TUPLES)
+    tupres = mysql_execute_query(hndl, [MYSQL_TYPE_LONG], [0]; opformat=MYSQL_TUPLES)
     println(tupres)
     for i in length(tupres)
         @test compare_rows(tupres[i], ArrayResultsPrep[i])
     end
 
-    mysql_stmt_close(stmt);
-    stmt_validate_metadata(stmt)
+    stmt_validate_metadata(hndl)
 end
 
-function stmt_validate_metadata(stmt)
+function stmt_validate_metadata(hndl)
     command = "SELECT * FROM Employee;"
-    stmt = mysql_stmt_init(hndl)
-    mysql_stmt_prepare(stmt, command)
-    meta = mysql_metadata(stmt)
+    mysql_stmt_prepare(hndl, command)
+    meta = mysql_metadata(hndl)
     @test meta.names[1] == "ID"
     @test meta.lens[1] == 11
     @test meta.mtypes[1] == MYSQL_TYPE_LONG
@@ -131,8 +122,6 @@ function stmt_validate_metadata(stmt)
     @test meta.mtypes[2] == MYSQL_TYPE_VAR_STRING
     @test meta.jtypes[2] == AbstractString
     @test meta.is_nullables[2] == true
-
-    mysql_stmt_close(stmt)
 end
 
 println("\n*** Running Prepared Statement Test ***\n")


### PR DESCRIPTION
Have `mysql_stmt_init` be called as part of `mysql_connect` and `mysql_stmt_close` as part of `mysql_disconnect`.