### PR TITLE
Enhanced connection

### DIFF
--- a/src/api.jl
+++ b/src/api.jl
@@ -19,7 +19,7 @@ function mysql_real_connect(mysqlptr::Ptr{Void},
                               passwd::AbstractString,
                               db::AbstractString,
                               port::Cuint,
-                              unix_socket::Ptr{Cchar},
+                              unix_socket::AbstractString,
                               @compat client_flag::UInt32)
 
     return ccall((:mysql_real_connect, mysql_lib),

--- a/src/consts.jl
+++ b/src/consts.jl
@@ -151,3 +151,11 @@ const MYSQL_TIMESTAMP_TIME     = 2
 
 @compat const NOT_NULL_FLAG = UInt32(1)
 const MYSQL_NO_DATA = 100
+
+const MYSQL_DEFAULT_PORT = 3306
+
+if is_windows()
+	MYSQL_DEFAULT_SOCKET = "MySQL"
+else
+	MYSQL_DEFAULT_SOCKET = "/tmp/mysql.sock"
+end

--- a/src/handy.jl
+++ b/src/handy.jl
@@ -35,11 +35,11 @@ function mysql_connect(host::AbstractString,
 end
 
 """
-    mysql_connect(host::AbstractString, user::AbstractString, passwd::AbstractString, db::AbstractString = "", port::Int64 = 3306, socket::AbstractString = "/var/run/mysqld/mysqld.sock"; opts = Dict())
+    mysql_connect(host::AbstractString, user::AbstractString, passwd::AbstractString, db::AbstractString = ""; port::Int64 = 3306, socket::AbstractString = "/var/run/mysqld/mysqld.sock", opts = Dict())
 
 Connect to a MySQL database.
 """
-function mysql_connect(host, user, passwd, db="", port=3306, socket="/var/run/mysqld/mysqld.sock"; opts = Dict())
+function mysql_connect(host, user, passwd, db=""; port=3306, socket="/var/run/mysqld/mysqld.sock", opts = Dict())
     return mysql_connect(host, user, passwd, db, convert(Cuint, port),
                          socket, CLIENT_MULTI_STATEMENTS, opts=opts)
 end

--- a/src/handy.jl
+++ b/src/handy.jl
@@ -35,11 +35,11 @@ function mysql_connect(host::AbstractString,
 end
 
 """
-    mysql_connect(host::AbstractString, user::AbstractString, passwd::AbstractString, db::AbstractString = ""; port::Int64 = 3306, socket::AbstractString = "/var/run/mysqld/mysqld.sock", opts = Dict())
+    mysql_connect(host::AbstractString, user::AbstractString, passwd::AbstractString, db::AbstractString = ""; port::Int64 = MYSQL_DEFAULT_PORT, socket::AbstractString = MYSQL_DEFAULT_SOCKET, opts = Dict())
 
 Connect to a MySQL database.
 """
-function mysql_connect(host, user, passwd, db=""; port=3306, socket="/var/run/mysqld/mysqld.sock", opts = Dict())
+function mysql_connect(host, user, passwd, db=""; port=MYSQL_DEFAULT_PORT, socket=MYSQL_DEFAULT_SOCKET, opts = Dict())
     return mysql_connect(host, user, passwd, db, convert(Cuint, port),
                          socket, CLIENT_MULTI_STATEMENTS, opts=opts)
 end

--- a/src/handy.jl
+++ b/src/handy.jl
@@ -20,7 +20,7 @@ function mysql_connect(host::AbstractString,
                         passwd::AbstractString,
                         db::AbstractString,
                         port::Cuint,
-                        unix_socket::Ptr{Cchar},
+                        unix_socket::AbstractString,
                         client_flag; opts = Dict())
     _mysqlptr = C_NULL
     _mysqlptr = mysql_init(_mysqlptr)
@@ -35,13 +35,13 @@ function mysql_connect(host::AbstractString,
 end
 
 """
-    mysql_connect(host::AbstractString, user::AbstractString, passwd::AbstractString, db::AbstractString = "", port::Int64 = 3306; opts = Dict())
+    mysql_connect(host::AbstractString, user::AbstractString, passwd::AbstractString, db::AbstractString = "", port::Int64 = 3306, socket::AbstractString = "/var/run/mysqld/mysqld.sock"; opts = Dict())
 
 Connect to a MySQL database.
 """
-function mysql_connect(host, user, passwd, db="", port=3306; opts = Dict())
+function mysql_connect(host, user, passwd, db="", port=3306, socket="/var/run/mysqld/mysqld.sock"; opts = Dict())
     return mysql_connect(host, user, passwd, db, convert(Cuint, port),
-                         convert(Ptr{Cchar}, C_NULL), CLIENT_MULTI_STATEMENTS, opts=opts)
+                         socket, CLIENT_MULTI_STATEMENTS, opts=opts)
 end
 
 """

--- a/src/handy.jl
+++ b/src/handy.jl
@@ -35,12 +35,12 @@ function mysql_connect(host::AbstractString,
 end
 
 """
-    mysql_connect(host::AbstractString, user::AbstractString, passwd::AbstractString, db::AbstractString = ""; opts = Dict())
+    mysql_connect(host::AbstractString, user::AbstractString, passwd::AbstractString, db::AbstractString = "", port::Int64 = 3306; opts = Dict())
 
 Connect to a MySQL database.
 """
-function mysql_connect(host, user, passwd, db=""; opts = Dict())
-    return mysql_connect(host, user, passwd, db, convert(Cuint, 0),
+function mysql_connect(host, user, passwd, db="", port=3306; opts = Dict())
+    return mysql_connect(host, user, passwd, db, convert(Cuint, port),
                          convert(Ptr{Cchar}, C_NULL), CLIENT_MULTI_STATEMENTS, opts=opts)
 end
 


### PR DESCRIPTION
Added two new optional parameters to mysql_connect :

- port

- socket

New parameters allow connection using a not standard port ( 3306 ) or a not default socket ( i.e. (/var/mysql/mysql.sock )

Examples:

```
julia> conn2 = mysql_connect("127.0.0.1", "support", "support", "", port=3307)
MySQL Handle
------------
Host: 127.0.0.1
User: support
DB:
```

```
julia> conn3 = mysql_connect("localhost", "support", "support", "", socket="/tmp/mysql-3307.sock")
MySQL Handle
------------
Host: localhost
User: support
DB:
```