### PR TITLE
Fix method overwrite warning

### DIFF
--- a/src/handy.jl
+++ b/src/handy.jl
@@ -159,7 +159,6 @@ function mysql_execute(hndl, command; opformat=MYSQL_DATA_FRAME)
         if result != C_NULL # if select query
             retval = convfunc(MySQLResult(hndl, result))
             push!(data, retval)
-            mysql_free_result(result)
 
         elseif mysql_field_count(hndl.mysqlptr) == 0
             push!(data, @compat Int(mysql_affected_rows(hndl.mysqlptr)))
@@ -310,8 +309,9 @@ function mysql_bind_array(typs, params)
 end
 
 function MySQLResult(hndl, resptr)
-    res = MySQLResult(hndl, resptr)
-    finalizer(ret, x -> mysql_free_result(res.resptr))
+    res = MySQLResult(hndl)
+    res.resptr = resptr
+    finalizer(res, x -> mysql_free_result(x.resptr))
     return res
 end
 

--- a/src/handy.jl
+++ b/src/handy.jl
@@ -308,13 +308,6 @@ function mysql_bind_array(typs, params)
     return bindarr
 end
 
-function MySQLResult(hndl, resptr)
-    res = MySQLResult(hndl)
-    res.resptr = resptr
-    finalizer(res, x -> mysql_free_result(x.resptr))
-    return res
-end
-
 """
     mysql_metadata(hndl::MySQLResult) -> MySQLMetadata
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -156,7 +156,12 @@ end
 type MySQLResult
     con::MySQLHandle
     resptr::MYSQL_RES
-    MySQLResult(con) = new(con, C_NULL)
+    function MySQLResult(hndl, resptr)
+        res = new(hndl, C_NULL)
+        res.resptr = resptr
+        finalizer(res, x -> mysql_free_result(x.resptr))
+        return res
+    end
 end
 
 """

--- a/src/types.jl
+++ b/src/types.jl
@@ -156,6 +156,7 @@ end
 type MySQLResult
     con::MySQLHandle
     resptr::MYSQL_RES
+    MySQLResult(con) = new(con, C_NULL)
 end
 
 """


### PR DESCRIPTION
Fix method overwrite warning for `MySQLResult` constructor.