### PR TITLE
Make mysql_execute type stable

### DIFF
--- a/src/handy.jl
+++ b/src/handy.jl
@@ -188,9 +188,9 @@ function mysql_execute(hndl::MySQLHandle; opformat=MYSQL_DATA_FRAME)
     naff = mysql_stmt_affected_rows(hndl)
     naff != typemax(typeof(naff)) && return naff        # Not a SELECT query
     if opformat == MYSQL_DATA_FRAME
-        return mysql_result_to_dataframe(hndl)
+        return [mysql_result_to_dataframe(hndl)]
     elseif opformat == MYSQL_TUPLES
-        return mysql_get_result_as_tuples(hndl)
+        return [mysql_get_result_as_tuples(hndl)]
     else
         throw(MySQLInterfaceError("Invalid output format: $opformat"))
     end

--- a/src/handy.jl
+++ b/src/handy.jl
@@ -146,8 +146,10 @@ function mysql_execute(hndl, command; opformat=MYSQL_DATA_FRAME)
 
     if opformat == MYSQL_DATA_FRAME
         convfunc = mysql_result_to_dataframe
+        narfunc = n -> DataFrame(num_affected_rows=[n])
     elseif opformat == MYSQL_TUPLES
         convfunc = mysql_get_result_as_tuples
+        narfunc = n -> (n, )
     else
         throw(MySQLInterfaceError("Invalid output format: $opformat"))
     end
@@ -159,7 +161,8 @@ function mysql_execute(hndl, command; opformat=MYSQL_DATA_FRAME)
             push!(data, retval)
 
         elseif mysql_field_count(hndl.mysqlptr) == 0
-            push!(data, Int(mysql_affected_rows(hndl.mysqlptr)))
+            n = Int(mysql_affected_rows(hndl.mysqlptr))
+            push!(data, narfunc(n))
         else
             throw(MySQLInterfaceError("Query expected to produce results but did not."))
         end

--- a/src/handy.jl
+++ b/src/handy.jl
@@ -172,9 +172,6 @@ function mysql_execute(hndl, command; opformat=MYSQL_DATA_FRAME)
         end
     end
 
-    if length(data) == 1
-        return data[1]
-    end
     return data
 end
 

--- a/test/test_basic.jl
+++ b/test/test_basic.jl
@@ -58,7 +58,7 @@ end
 
 function show_results()
     command = """SELECT * FROM Employee;"""
-    dframe = mysql_execute(hndl, command)
+    dframe = mysql_execute(hndl, command)[1]
     println("\n *** Results as Dataframe: \n", dframe)
     println("\n *** Expected Result: \n", DataFrameResults)
     @test dfisequal(dframe, DataFrameResults)
@@ -72,7 +72,7 @@ function show_results()
     end
 
     println("\n *** Results as tuples: \n")
-    tupres = mysql_execute(hndl, command; opformat=MYSQL_TUPLES)
+    tupres = mysql_execute(hndl, command; opformat=MYSQL_TUPLES)[1]
     println(tupres)
     for i in length(tupres)
         @test compare_rows(tupres[i], ArrayResults[i])

--- a/test/test_prep.jl
+++ b/test/test_prep.jl
@@ -84,7 +84,7 @@ end
 function show_results()
     command = "SELECT * FROM Employee WHERE ID > ?;"
     mysql_stmt_prepare(hndl, command)
-    dframe = mysql_execute(hndl, [MYSQL_TYPE_LONG], [0])
+    dframe = mysql_execute(hndl, [MYSQL_TYPE_LONG], [0])[1]
     println("\n *** Results as dataframe: \n", dframe)
     println("\n *** Expected result: \n", DataFrameResultsPrep)
     @test dfisequal(dframe, DataFrameResultsPrep)
@@ -100,7 +100,7 @@ function show_results()
 
     mysql_stmt_prepare(hndl, command)
     println("\n *** Results as tuples: \n")
-    tupres = mysql_execute(hndl, [MYSQL_TYPE_LONG], [0]; opformat=MYSQL_TUPLES)
+    tupres = mysql_execute(hndl, [MYSQL_TYPE_LONG], [0]; opformat=MYSQL_TUPLES)[1]
     println(tupres)
     for i in length(tupres)
         @test compare_rows(tupres[i], ArrayResultsPrep[i])


### PR DESCRIPTION
Address #84 
1) Always return `Vector{X}` when user requests output format as X.
2) Wrap number of affected rows in requested type.