### PR TITLE
switch to missing

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,5 @@
 julia 0.5
-DataFrames
+DataFrames 0.11
 Compat 0.17.0
 ConfParser
+Missings

--- a/src/handy.jl
+++ b/src/handy.jl
@@ -297,7 +297,7 @@ function mysql_bind_array(typs, params)
     bindarr = MYSQL_BIND[]
     for (typ, val) in zip(typs, params)
         #Is the value one of three different versions of Null?
-        if (isdefined(:DataArrays)&&(typeof(val)==DataArrays.NAtype))||(isdefined(:NullableArrays)&&(typeof(val)<:Nullable)&&(val.isnull))||(val==nothing) 
+        if (typeof(val) == Missing) || (val==nothing) 
             push!(bindarr, mysql_bind_init(MYSQL_TYPE_NULL, "NULL"))
         else
             push!(bindarr, mysql_bind_init(typ, val)) #Otherwise


### PR DESCRIPTION
I've updated MySQL to use DataFrames 0.11 and Missings. I can now run the examples in the README without issues. Unfortunately, I couldn't run the tests locally as I got:

```julia
julia> mysql_connect(HOST, USER, PASS, "")
ERROR: Can't connect to MySQL server on '127.0.0.1' (61)
```

on [this line](https://github.com/JuliaDB/MySQL.jl/blob/master/test/test_common.jl#L19) so tests are still in need of updating. If anybody knows how to fix the error I can update the tests.

